### PR TITLE
Potential fix for code scanning alert no. 54: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/jerffesonslins-svg/juice-shop-ada-1466/security/code-scanning/54](https://github.com/jerffesonslins-svg/juice-shop-ada-1466/security/code-scanning/54)

To fix the issue, you should remove any direct interpolation of user input into the `$where` clause of a MongoDB query. Instead, use standard query operators that do *not* evaluate JavaScript code. In this specific context, the code is searching for an order using its ID, so you can use a direct equality query (`{ orderId: id }`) instead of `$where`. This is both more performant and eliminates the risk of code injection. The fix involves replacing the following block:

```ts
db.ordersCollection.find({ $where: `this.orderId === '${id}'` })
```

with:

```ts
db.ordersCollection.find({ orderId: id })
```

Only code inside routes/trackOrder.ts needs to be updated. No additional methods or imports are required, as only the query itself must change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
